### PR TITLE
Update onPushDocumentation.yml

### DIFF
--- a/.github/workflows/onPushDocumentation.yml
+++ b/.github/workflows/onPushDocumentation.yml
@@ -2,7 +2,7 @@ name: Compile Typst
 
 on:
   push:
-    branches: [ "Documentation/**", "Documentation" ]
+    branches: [ "Documentation-**", "Documentation" ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Questa modifica serve per far funzionare l'automazione della documentazione su branch chiamati `Documentation-**`, poiché è impossibile creare il branch `Documentation/**`.

Per informazioni, vedi https://stackoverflow.com/questions/45141188/git-fatal-cannot-lock-ref.