### PR TITLE
[VE] v1.0.0 verbale del 10-02-2026

### DIFF
--- a/src/RTB/VerbaliEsterni/2026-02-10.typ
+++ b/src/RTB/VerbaliEsterni/2026-02-10.typ
@@ -6,7 +6,7 @@
   registro-modifiche: (
     (
       "1.0.0",
-      "13/02/2026",
+      "14/02/2026",
       "Riccardo Graziani",
       "Jaume Bernardi",
       "Versione stabile verbale esterno del 10/02/2026",


### PR DESCRIPTION
Prima versione del verbale esterno del 10-02-2026. Unica cosa da vedere è se va bene mettere come attività conseguente solo la creazione della presentazione legata alle tecnologie per la RTB.